### PR TITLE
install_java#1 attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Attributes
 * node['servicemix']['home'] - Installation location, default `/opt`.
 * node['servicemix']['uid'] - OS user ID that owns all files and runs the background service, default `smx`.
 * node['servicemix']['gid'] = OS group ID that owns all files, default `smx`.
+* node['servicemix']['install_java'] - Whether or not to install Java, default `true`
 
 License and Author
 ------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,3 +22,4 @@ default['servicemix']['version'] = '5.4.0'
 default['servicemix']['home'] = '/opt'
 default['servicemix']['uid'] = 'smx'
 default['servicemix']['gid'] = 'smx'
+default['servicemix']['install_java'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'java::default'
+include_recipe 'java::default' if node['servicemix']['install_java']
 
 tmp = Chef::Config[:file_cache_path]
 mirror = node['servicemix']['mirror']


### PR DESCRIPTION
By default this cookbook will try to install Java, which is not always desired. Therefore having a flag that would enable/disable the java installation, would be beneficial.